### PR TITLE
게시판 api 만들기 - Data REST 적용 및 테스트 정의

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    // api
+    implementation 'org.springframework.boot:spring-boot-starter-data-rest'
+    // api를 테스트할 수 있게 하기 위해 추가
+    implementation 'org.springframework.data:spring-data-rest-hal-explorer'
 
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'mysql:mysql-connector-java'

--- a/src/main/java/com/fastcampus/projectboard/repository/ArticleCommentRepository.java
+++ b/src/main/java/com/fastcampus/projectboard/repository/ArticleCommentRepository.java
@@ -1,8 +1,10 @@
 package com.fastcampus.projectboard.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
 import com.fastcampus.projectboard.domain.ArticleComment;
 
+@RepositoryRestResource
 public interface ArticleCommentRepository extends JpaRepository<ArticleComment, Long> {
 }

--- a/src/main/java/com/fastcampus/projectboard/repository/ArticleRepository.java
+++ b/src/main/java/com/fastcampus/projectboard/repository/ArticleRepository.java
@@ -1,8 +1,10 @@
 package com.fastcampus.projectboard.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
 import com.fastcampus.projectboard.domain.Article;
 
+@RepositoryRestResource
 public interface ArticleRepository extends JpaRepository<Article, Long> {
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,7 +31,8 @@ spring:
     init:
       mode: always
   # thymeleaf.cache: false
-  # data:
-    # rest:
-      # base-path: /api
+  data:
+    rest:
+      base-path: /api
+      detection-strategy: annotated
 

--- a/src/test/java/com/fastcampus/projectboard/controller/DataRestTest.java
+++ b/src/test/java/com/fastcampus/projectboard/controller/DataRestTest.java
@@ -1,0 +1,81 @@
+package com.fastcampus.projectboard.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+@DisplayName("Data REST - API 테스트")
+@Transactional
+@AutoConfigureMockMvc
+@SpringBootTest
+class DataRestTest {
+
+	private final MockMvc mvc;
+
+	public DataRestTest(@Autowired MockMvc mvc) {
+		this.mvc = mvc;
+	}
+
+	@DisplayName("[api] 게시글 리스트 조회")
+	@Test
+	void givenNothing_whenRequestingArticles_thenReturnsArticlesJsonResponse() throws Exception {
+		// Given
+
+		// When & Then
+		mvc.perform(get("/api/articles"))
+			.andExpect(status().isOk())
+			.andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+	}
+
+	@DisplayName("[api] 게시글 단건 조회")
+	@Test
+	void givenNothing_whenRequestingArticle_thenReturnsArticleJsonResponse() throws Exception {
+		// Given
+
+		// When & Then
+		mvc.perform(get("/api/articles/1"))
+			.andExpect(status().isOk())
+			.andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+	}
+
+	@DisplayName("[api] 게시글 -> 댓글 리스트 조회")
+	@Test
+	void givenNothing_whenRequestingArticleCommentsFromArticle_thenReturnsArticleCommentsJsonResponse() throws Exception {
+		// Given
+
+		// When & Then
+		mvc.perform(get("/api/articles/1/articleComments"))
+			.andExpect(status().isOk())
+			.andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+	}
+
+	@DisplayName("[api] 댓글 리스트 조회")
+	@Test
+	void givenNothing_whenRequestingArticleComments_thenReturnsArticleCommentsJsonResponse() throws Exception {
+		// Given
+
+		// When & Then
+		mvc.perform(get("/api/articleComments"))
+			.andExpect(status().isOk())
+			.andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+	}
+
+	@DisplayName("[api] 댓글 단건 조회")
+	@Test
+	void givenNothing_whenRequestingArticleComment_thenReturnsArticleCommentJsonResponse() throws Exception {
+		// Given
+
+		// When & Then
+		mvc.perform(get("/api/articleComments/1"))
+			.andExpect(status().isOk())
+			.andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+	}
+}


### PR DESCRIPTION
게시글 댓글 데이터는 간편하게 Spring Data REST로 서비스하고, 해당 api들의 존재 여부만 체크하게끔 통합테스트 작성